### PR TITLE
Blade URL helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "philo/laravel-blade": "^3.1"
     },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "Circulate\\": "src/"
         }

--- a/src/Circulate.php
+++ b/src/Circulate.php
@@ -48,7 +48,6 @@ class Circulate
      */
     public function __construct($basePath, $logger)
     {
-        echo 'test';
         $this->logger = $logger;
 
         $this->settings        = $this->settings();

--- a/src/Circulate.php
+++ b/src/Circulate.php
@@ -101,6 +101,7 @@ class Circulate
     {
         return [
             'site_title'   => $this->env('SITE_TITLE', ''),
+            'site_url'     => $this->env('SITE_URL', ''),
             'theme'        => $this->env('THEME', 'default'),
             'cache_path'   => $this->env('CACHE_PATH', '_storage/cache'),
             'content_path' => $this->env('CONTENT_PATH', '_content'),

--- a/src/Circulate.php
+++ b/src/Circulate.php
@@ -48,6 +48,7 @@ class Circulate
      */
     public function __construct($basePath, $logger)
     {
+        echo 'test';
         $this->logger = $logger;
 
         $this->settings        = $this->settings();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,14 @@
+<?php
+
+if (!function_exists('url')) {
+    /**
+     * Generate an absolute URL.
+     *
+     * @param string $path
+     * @return string
+     */
+    function url($path = '')
+    {
+        echo $path;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,26 @@
 <?php
 
+if (!function_exists('asset')) {
+    /**
+     * Generate an absolute URL to a theme asset.
+     *
+     * @param string $path
+     * @return string
+     */
+    function asset($path = '')
+    {
+		$url = getenv('SITE_URL') ?: '';
+		$theme = getenv('THEME') ?: 'default';
+		$url = rtrim($url, '/') . '/themes/' . $theme;
+
+		if (empty($path)) {
+			return $url;
+		}
+		
+		return rtrim($url, '/') . '/' . ltrim($path, '/');
+    }
+}
+
 if (!function_exists('url')) {
     /**
      * Generate an absolute URL.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,6 +9,12 @@ if (!function_exists('url')) {
      */
     function url($path = '')
     {
-        echo $path;
+		$url = getenv('SITE_URL') ?: '';
+
+		if (empty($path)) {
+			return $url;
+		}
+		
+		return rtrim($url, '/') . '/' . ltrim($path, '/');
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,15 +9,15 @@ if (!function_exists('asset')) {
      */
     function asset($path = '')
     {
-		$url = getenv('SITE_URL') ?: '';
-		$theme = getenv('THEME') ?: 'default';
-		$url = rtrim($url, '/') . '/themes/' . $theme;
+        $url = getenv('SITE_URL') ?: '';
+        $theme = getenv('THEME') ?: 'default';
+        $url = rtrim($url, '/') . '/themes/' . $theme;
 
-		if (empty($path)) {
-			return $url;
-		}
-		
-		return rtrim($url, '/') . '/' . ltrim($path, '/');
+        if (empty($path)) {
+            return $url;
+        }
+        
+        return rtrim($url, '/') . '/' . ltrim($path, '/');
     }
 }
 
@@ -30,12 +30,12 @@ if (!function_exists('url')) {
      */
     function url($path = '')
     {
-		$url = getenv('SITE_URL') ?: '';
+        $url = getenv('SITE_URL') ?: '';
 
-		if (empty($path)) {
-			return $url;
-		}
-		
-		return rtrim($url, '/') . '/' . ltrim($path, '/');
+        if (empty($path)) {
+            return $url;
+        }
+        
+        return rtrim($url, '/') . '/' . ltrim($path, '/');
     }
 }


### PR DESCRIPTION
Adds two new helpers for generating absolute URLs in blade templates. Uses `SITE_URL` added to .env file.

```
url('/about') 
http://mysite.com/about
```

and 

```
asset('/css/style.css')
http://mysite.com/themes/default/css/style.css
```